### PR TITLE
Eliminate glitch pulse that requires special IRQ handling

### DIFF
--- a/Receiver/Receiver.ino
+++ b/Receiver/Receiver.ino
@@ -33,8 +33,9 @@ void setup() {
     }
 
     // Setting interrupt PIN to output is no problem, PIN must be normal HIGH
-    pinMode(INTERRUPT, OUTPUT);
+    // Avoid glitch pulse by setting output state before switching pin to output mode
     digitalWrite(INTERRUPT, HIGH);
+    pinMode(INTERRUPT, OUTPUT);
     
     // Setting up helper variables to determine EOF later on
     counter = 0;

--- a/bootloader.asm
+++ b/bootloader.asm
@@ -36,7 +36,6 @@ POSITION_MENU = $3fdc                           ; initialize positions for menu 
 POSITION_CURSOR = $3fdd
 WAIT = $3fdb
 WAIT_C = $18                                    ; global sleep multiplicator (adjust for slower clock)
-ISR_FIRST_RUN = $3fda                           ; used to determine first run of the ISR
 
 PROGRAM_LOCATION = $0200                        ; memory location for user programs
 
@@ -267,9 +266,6 @@ CURRENT_RAM_ADDRESS_H = Z1
 LOADING_STATE = Z2
     lda #%01111111                              ; we disable all 6522 interrupts!!!
     sta IER
-
-    lda #0                                      ; for a reason I dont get, the ISR is triggered...
-    sta ISR_FIRST_RUN                           ; one time before the first byte arrives, so we mitigate here
 
     jsr LCD__clear_video_ram
     lda #<message4                              ; Rendering a message
@@ -1115,14 +1111,6 @@ CURRENT_RAM_ADDRESS = Z0                        ; a RAM address handle for indir
     pha
     tya
     pha
-                                                ; for a reason I dont get, the ISR is called once with 0x00
-    lda ISR_FIRST_RUN                           ; check whether we are called for the first time
-    bne .write_data                             ; if not, just continue writing
-
-    lda #1                                      ; otherwise set the first time marker
-    sta ISR_FIRST_RUN                           ; and return from the interrupt
-
-    jmp .doneisr
 
 .write_data:
     lda #$01                                    ; progressing state of loading operation


### PR DESCRIPTION
I believe this eliminates the glitch low-active pulse in the Receiver.ino IRQB signal (so the associated handling can be removed from the bootloader).

- [x]  tested on breadboard 65c02 with Arduino Mega 2560

cc @janroesner 

![image](https://user-images.githubusercontent.com/612007/81774859-69dd2400-94a0-11ea-9e3d-9c0bcff3ccee.png)
