### PR TITLE
Revert special IRQ handling and fix post Load sequence to return to menu

### DIFF
--- a/Receiver/Receiver.ino
+++ b/Receiver/Receiver.ino
@@ -33,9 +33,8 @@ void setup() {
     }
 
     // Setting interrupt PIN to output is no problem, PIN must be normal HIGH
-    // Avoid glitch pulse by setting output state before switching pin to output mode
-    digitalWrite(INTERRUPT, HIGH);
     pinMode(INTERRUPT, OUTPUT);
+    digitalWrite(INTERRUPT, HIGH);
     
     // Setting up helper variables to determine EOF later on
     counter = 0;

--- a/bootloader.asm
+++ b/bootloader.asm
@@ -295,7 +295,7 @@ LOADING_STATE = Z2
     cmp #$00                                    ; the ISR will set to $01 as soon as a byte is read
     beq .wait_for_first_data
 
-.loading_data
+.loading_data:
     lda #$02                                    ; assuming we're done loading, we set loading state to $02
     sta LOADING_STATE
 
@@ -309,15 +309,23 @@ LOADING_STATE = Z2
     lda LOADING_STATE                           ; check back loading state, which was eventually updated by the ISR
     cmp #$02
     bne .loading_data
-                                               ; when no data came in in last * cycles, we're done loading  
+                                                ; when no data came in in last * cycles, we're done loading  
 .done_loading:
-    jsr LCD__clear_video_ram
+    lda #%11111111                              ; Reset VIA ports for output, set all pins on port B to output
+    ldx #%11100000                              ; set top 3 pins and bottom ones to on port A to output, 5 middle ones to input
+    jsr VIA__configure_ddrs
 
+    jsr LCD__clear_video_ram
     lda #<message6
     ldy #>message6
     jsr LCD__print
-    lda #$ff                                    ; wait a moment before we return to main menu
+
+    ldx #$20                                    ; wait a moment before we return to main menu
+    lda #$ff
+.loop_messagedisplay:
     jsr LIB__sleep
+    dex
+    bne .loop_messagedisplay
 
     rts
 
@@ -1041,7 +1049,7 @@ LIB__sleep:
     rts
 
 message:
-    .asciiz "Sixty/5o2       Bootloader v0.1"
+    .asciiz "Sixty/5o2       Bootloader v0.2"
 message2:
     .asciiz "Enter Command..."
 message3:


### PR DESCRIPTION
1) The change introduced in Receiver.ino to write the INTERRUPT pin high before setting pin mode to output does not work for the Arduino Nano Every. Default Arduino behaviour is to reset upon USB connection so reinstating the special IRQ handling to handle what I believe to be the most common behaviour of the Arduino. Tested with Arduino Nano Every and UNO Rev3.

2) Changed the post Load bootloader to reset VIA ports to output again after Load completes so that "Loading done!" message displays and program returns to main menu without needing to reset the 6502.

cc @janroesner 